### PR TITLE
Update Jest global settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'node',
   globalSetup: '<rootDir>/tests/build.js',
+  globalTeardown: '<rootDir>/tests/teardown.js',
 };

--- a/tests/build.js
+++ b/tests/build.js
@@ -1,8 +1,5 @@
-const { Builder } = require('nuxt');
-const setup = require('./setup.js');
+const { build } = require('./setup.js');
 
 module.exports = async () => {
-  const nuxt = setup();
-  await new Builder(nuxt).build();
-  nuxt.close();
+  await build();
 };

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -1,13 +1,5 @@
-const setup = require('./setup.js');
+const { nuxt } = require('./setup.js');
 const { testComponent } = require('./nuxt.config.js');
-
-let nuxt;
-beforeAll(() => {
-  nuxt = setup();
-});
-afterAll(() => {
-  nuxt.close();
-});
 
 describe('Example: Vuex test', () => {
   it('Get state', async () => {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,14 @@
-const { Nuxt } = require('nuxt');
+const { Nuxt, Builder } = require('nuxt');
 const { config } = require('./nuxt.config.js');
 
-module.exports = () => new Nuxt(config);
+const nuxt = new Nuxt(config);
+
+module.exports = {
+  nuxt,
+  build: async () => {
+    await new Builder(nuxt).build();
+  },
+  teardown: () => {
+    nuxt.close();
+  },
+};

--- a/tests/teardown.js
+++ b/tests/teardown.js
@@ -1,0 +1,3 @@
+const { teardown } = require('./setup.js');
+
+module.exports = () => teardown();


### PR DESCRIPTION
Jest で Nuxt.js のビルドから終了までのフローを見直しました。
`jest.config.js` の `globals` で定義したキーに Nuxt.js のインスタンスを代入できないようなので諦めていましたが、別ファイルでインスタンスの生成を行うことで各テストファイルから参照できるようにしました。

この変更により、各テストファイルでインスタンスの生成、終了をする必要なくなり、時間の短縮ができたのではないかと思います。
また、コードの見通しもよくなりましたのでテストにだけ集中できるかと思います。