### PR TITLE
Fix Babel config for Jest (Replace babel.config.js with .babelrc)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "test": { "presets": ["env"] }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    test: { presets: ['env'] },
-  },
-};


### PR DESCRIPTION
テストの際に `import` 文のパースエラーが発生していたので調査したところ、Jest は `.babelrc` しか設定ファイルとしてサポートしていないことが判り修正しました。