### PR TITLE
スマートフォンの場合ボタン非表示、プラグイン追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ module.exports = {
   /*
   ** Customize the progress-bar color
   */
-  loading: { color: '#FFFFFF' },
+  loading: false,
 
   /*
   ** Global CSS
@@ -33,6 +33,7 @@ module.exports = {
   plugins: [
     '@/plugins/axios',
     '@/plugins/element-ui',
+    '@/plugins/vue-touch',
   ],
 
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,6 +33,7 @@ module.exports = {
   plugins: [
     '@/plugins/axios',
     '@/plugins/element-ui',
+    '@/plugins/window-state',
     '@/plugins/vue-touch',
   ],
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,7 @@
 <template>
     <div class="main">
+      <!-- デバッグ用 -->
+      画面サイズ: {{ $window.width }} x {{ $window.height }}
       <div class="board"
         @touchstart="setInitPos($event)"
         @touchmove="gridMove($event)"
@@ -19,7 +21,7 @@
             <div
               class="piece"
               v-if="getUserId(i)"
-              :style="getUserId(i) === currentUser ? 'background:#444;color:white' :''"
+              :style="getUserId(i) === currentUser ? 'background:#444;color:white' : ''"
             > {{ getUserId(i) }}</div>
           </div>
         </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,45 +1,47 @@
 <template>
     <div class="main">
       <div class="board"
-      @touchstart="setInitPos($event)"
-      @touchmove="gridMove($event)"
-      @touchend="resetInitPos">
-        <div>
-          <div
-            class="cell"
-            v-for="i in Math.pow(grid, 2)"
-            :key="i"
-            :style="
-            `width: ${100/grid}%;
-            background: ${putAbleCheck(i) ? '#0652DD': ''};
-            cursor: ${putAbleCheck(i) ? 'pointer' : ''}`"
-          >
-            <div @click="send(i)">
-              <div
+        @touchstart="setInitPos($event)"
+        @touchmove="gridMove($event)"
+        @touchend="resetInitPos"
+      >
+      <div>
+        <div
+          class="cell"
+          v-for="i in Math.pow(grid, 2)"
+          :key="i"
+          :style="
+          `width: ${100/grid}%;
+          background: ${putAbleCheck(i) ? '#0652DD': ''};
+          cursor: ${putAbleCheck(i) ? 'pointer' : ''}`"
+        >
+          <div @click="send(i)">
+            <div
               class="piece"
               v-if="getUserId(i)"
               :style="getUserId(i) === currentUser ? 'background:#444;color:white' :''"
-              > {{ getUserId(i) }}</div>
-            </div>
+            > {{ getUserId(i) }}</div>
           </div>
         </div>
       </div>
+    </div>
 
-      <UserSelector
-        :number="number"
-        :current="currentUser"
-        @change="changeCurrentUser"
-      />
+    <UserSelector
+      :number="number"
+      :current="currentUser"
+      @change="changeCurrentUser"
+    />
 
-      <ResetButton />
-
-      <button class="minus btn" @click="zoomout"> - </button>
-      <button class="plus btn" @click="zoomin"> + </button>
+    <ResetButton />
+    <button class="minus btn" @click="zoomout"> - </button>
+    <button class="plus btn" @click="zoomin"> + </button>
+    <div v-if="checkPC">
       <button class="btn up" @click="moveUp"> ↑ </button>
       <button class="btn right" @click="moveRight"> → </button>
       <button class="btn down" @click="moveDown"> ↓ </button>
       <button class="btn left" @click="moveLeft"> ← </button>
     </div>
+  </div>
 </template>
 
 <script>
@@ -54,11 +56,9 @@ export default {
     UserSelector,
     ResetButton,
   },
-
   async fetch({ store }) {
     await store.dispatch('getBoard');
   },
-
   mounted() {
     setInterval(async () => {
       this.getBoard();
@@ -75,6 +75,14 @@ export default {
       'xHalf',
       'yHalf',
     ]),
+    checkPC() {
+      const { userAgent } = navigator;
+      if (userAgent.indexOf('iPhone') > -1 || userAgent.indexOf('iPod') > -1
+          || userAgent.indexOf('Android') > -1) {
+        return false;
+      }
+      return true;
+    },
     getUserId() {
       return (i) => {
         const half = Math.floor(this.grid / 2);

--- a/plugins/vue-touch.js
+++ b/plugins/vue-touch.js
@@ -1,0 +1,7 @@
+import Vue from 'vue';
+
+const VueTouch = require('vue-touch');
+
+export default () => {
+  Vue.use(VueTouch, { name: 'v-touch' });
+};

--- a/plugins/window-state.js
+++ b/plugins/window-state.js
@@ -1,0 +1,25 @@
+import Vue from 'vue';
+
+export default () => {
+  const windowStatePlugin = {
+    install() {
+      // ウィンドウの状態
+      const state = {
+        width: 0,
+        height: 0,
+      };
+      // ウィンドウのサイズを取得
+      const onResize = () => {
+        state.width = document.documentElement.clientWidth;
+        state.height = document.documentElement.clientHeight;
+      };
+      window.addEventListener('resize', onResize);
+      onResize();
+
+      // プロパティ $window を定義
+      Vue.util.defineReactive(Vue.prototype, '$window', state);
+    },
+  };
+
+  Vue.use(windowStatePlugin);
+};


### PR DESCRIPTION
### #54 スマートフォンの場合ボタン非表示 対応
- pages/index.vue
以下のボタンは現状残しています。
1. ズームイン・アウトボタン:  #52 が未実装のため
2. リセットボタン: デバッグ用であり、最終的に削除予定のため

### プラグイン追加
- nuxt.config.js
+α）画面上部のローディング表示を非表示に変更
- plugins/vue-touch.js
- plugins/window-state.js
上記プラグインは、今後対応する #52 ズームイン・アウトのピンチ対応  #53 盤面の全画面化 で使用予定