### PR TITLE
本番環境でのuserId初期設定一時変更、マウスホイール操作でのズーム方向反転

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,6 +43,19 @@
           :style="piece.userId === currentUser ? 'fill: #444;' : ''"
         />
 
+        <!-- デバッグ用(色を設定するまでは本番環境でも表示) -->
+        <text
+          class="userid"
+          v-for="(piece, i) in pieces"
+          :key="'userId' + i"
+          :font-size="calcGridWidth() * 0.2"
+          :x="calcObjPos(piece).x"
+          :y="calcObjPos(piece).y + calcGridWidth() * 0.05"
+          :style="piece.userId === currentUser ? 'fill: #fff' : ''"
+        >
+          {{ piece.userId ? piece.userId : 'null' }}
+        </text>
+
         <circle
           class="candidate"
           v-for="(candidate, i) in candidates"
@@ -82,6 +95,10 @@
     <div class="score">
       <div>Score</div>
       <div>{{ score }}</div>
+      <!-- デバッグ用 -->
+      <div v-if="score === 0">
+        {{ '3秒長押しして下さい' }}
+      </div>
     </div>
 
     <Ranking />
@@ -386,11 +403,17 @@ body {
 .score > div {
   box-sizing: border-box;
   width: 100px;
-  height: 48px;
+  height: 35px;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  font-size: 150%;
+  font-size: 100%;
   border-bottom: 1px solid #555;
 }
+
+.userid {
+  text-anchor: middle;
+  fill: #444;
+}
+
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -95,7 +95,7 @@
     <div class="score">
       <div>Score</div>
       <div>{{ score }}</div>
-      <!-- デバッグ用 -->
+      <!-- 仮 -->
       <div v-if="score === 0">
         {{ '3秒長押しして下さい' }}
       </div>
@@ -279,9 +279,9 @@ export default {
     handleScroll(e) {
       e.preventDefault();
       // ホイール移動量取得
-      if (e.deltaY < 0) {
+      if (e.deltaY > 0) {
         this.zoomout();
-      } else if (e.deltaY > 0) {
+      } else if (e.deltaY < 0) {
         this.zoomin();
       }
     },

--- a/store/index.js
+++ b/store/index.js
@@ -104,8 +104,12 @@ export const mutations = {
 };
 
 export const actions = {
-  async getUserId({ commit }) {
+  async getUserId({ commit, state }) {
     let userId = localStorage.getItem(USER_KEY_NAME);
+    // デバッグ用(本番環境では無効)
+    if (process.env.NODE_ENV === 'production') {
+      userId = state.currentUser;
+    }
     if (!userId) {
       const seedLetters = 'abcdefghijklmnopqrstuvwxyz';
       const seedNumbers = '0123456789';


### PR DESCRIPTION
- 本番環境でのuserId初期設定一時変更
ユーザーIDのハッシュ化に向けて準備中ですが、サーバー側の準備が出来ていないため、本番環境では一時的に元に戻し、ユーザーセレクターでの番号選択とします。
- デバッグ用追加
userIdを表示しました。最終的には表示しませんが、分かりづらいので、一旦本番環境でも表示します。
@Yohei1127 さんのカウント表示が用意出来るまでの間、取り急ぎスコアが0のとき、スコア表示部に `3秒長押しして下さい` と表示します。
- マウスホイール操作でのズーム方向反転
GoogleMapに合わせて変更