### PR TITLE
ユーザーネーム登録機能追加

### DIFF
--- a/components/UserNameInput.vue
+++ b/components/UserNameInput.vue
@@ -12,12 +12,11 @@
                 v-model="name"
                 minlength="4"
                 maxlength="15"
+                pattern="^[a-z0-9]([_a-z0-9]){2,13}[a-z0-9]$"
                 required
               >
               <div class="sendBtn" @click="sendName">send</div>
             </form>
-            <div v-if="error1" class="errorMsg">大文字を使わないでください</div>
-            <div v-if="error2" class="errorMsg">特殊記号文字を使わないでください</div>
           </div>
         </transition>
       </div>
@@ -34,20 +33,12 @@ export default {
   data() {
     return {
       name: '',
-      error1: false,
-      error2: false,
     };
   },
   methods: {
     ...mapActions(['getAccessToken']),
     sendName() {
-      this.error1 = false;
-      this.error2 = false;
-      const reg1 = new RegExp(/[A-Z]/g);
-      const reg2 = new RegExp(/['!#$%&()*+,.:;=?"@[\]|^{}-]/g);
-      if (this.name.match(reg1)) this.error1 = true;
-      if (this.name.match(reg2)) this.error2 = true;
-      if (!this.error1 && !this.error2) this.getAccessToken();
+      this.getAccessToken();
     },
   },
 };
@@ -65,7 +56,6 @@ export default {
 .initMsg {
   width: 80%;
   height: 30%;
-  /* background: #fff; */
   position: absolute;
   top: 50%;
   left: 50%;

--- a/components/UserNameInput.vue
+++ b/components/UserNameInput.vue
@@ -8,7 +8,6 @@
             <form class="form" @submit.prevent="sendName">
               <input type="text"
                 class="input"
-                placeholder="'test'(仮)と入力"
                 v-model="name"
                 minlength="4"
                 maxlength="15"

--- a/components/UserNameInput.vue
+++ b/components/UserNameInput.vue
@@ -4,10 +4,20 @@
         <transition name="instruction">
           <div class="initMsg">
             <div class="title">名前を入力してください</div>
+            <div class="condition">アルファベット小文字、数字、アンダースコアのみが使えます</div>
             <form class="form" @submit.prevent="sendName">
-              <input type="text" class="input">
+              <input type="text"
+                class="input"
+                placeholder="'test'(仮)と入力"
+                v-model="name"
+                minlength="4"
+                maxlength="15"
+                required
+              >
               <div class="sendBtn" @click="sendName">send</div>
             </form>
+            <div v-if="errorMsg1" class="errorMsg">大文字を使わないでください</div>
+            <div v-if="errorMsg2" class="errorMsg">特殊記号文字を使わないでください</div>
           </div>
         </transition>
       </div>
@@ -21,10 +31,23 @@ export default {
   props: [
     'nameInput',
   ],
+  data() {
+    return {
+      name: '',
+      errorMsg1: false,
+      errorMsg2: false,
+    };
+  },
   methods: {
     ...mapActions(['getAccessToken']),
     sendName() {
-      this.getAccessToken();
+      this.errorMsg1 = false;
+      this.errorMsg2 = false;
+      const reg1 = new RegExp(/[A-Z]/g);
+      const reg2 = new RegExp(/['!#$%&()*+,.:;=?"@[\]|^{}-]/g);
+      if (this.name.match(reg1)) this.errorMsg1 = true;
+      if (this.name.match(reg2)) this.errorMsg2 = true;
+      // this.getAccessToken();
     },
   },
 };
@@ -57,12 +80,23 @@ export default {
   font-family: serif;
 }
 
-.form {
+.condition {
   margin: 30px auto 0;
+  font-size: 12px;
+  color: white;
+}
+
+.form {
+  margin: 0 auto;
   display: flex;
   justify-content: center;
   width: auto;
   text-align: center;
+}
+
+.errorMsg{
+  font-size: 18px;
+  color:red;
 }
 
 .input {
@@ -100,7 +134,6 @@ export default {
 }
 
 /* モーダル部分 */
-
 .modal-enter {
   opacity: 0;
 }
@@ -112,9 +145,6 @@ export default {
 .modal-enter-active{
   transition: opacity 2s;
 }
-
-/* 案内部分 */
-
 
 @media screen and (max-width: 800px){
   .startBtn {

--- a/components/UserNameInput.vue
+++ b/components/UserNameInput.vue
@@ -16,8 +16,8 @@
               >
               <div class="sendBtn" @click="sendName">send</div>
             </form>
-            <div v-if="errorMsg1" class="errorMsg">大文字を使わないでください</div>
-            <div v-if="errorMsg2" class="errorMsg">特殊記号文字を使わないでください</div>
+            <div v-if="error1" class="errorMsg">大文字を使わないでください</div>
+            <div v-if="error2" class="errorMsg">特殊記号文字を使わないでください</div>
           </div>
         </transition>
       </div>
@@ -34,20 +34,20 @@ export default {
   data() {
     return {
       name: '',
-      errorMsg1: false,
-      errorMsg2: false,
+      error1: false,
+      error2: false,
     };
   },
   methods: {
     ...mapActions(['getAccessToken']),
     sendName() {
-      this.errorMsg1 = false;
-      this.errorMsg2 = false;
+      this.error1 = false;
+      this.error2 = false;
       const reg1 = new RegExp(/[A-Z]/g);
       const reg2 = new RegExp(/['!#$%&()*+,.:;=?"@[\]|^{}-]/g);
-      if (this.name.match(reg1)) this.errorMsg1 = true;
-      if (this.name.match(reg2)) this.errorMsg2 = true;
-      // this.getAccessToken();
+      if (this.name.match(reg1)) this.error1 = true;
+      if (this.name.match(reg2)) this.error2 = true;
+      if (!this.error1 && !this.error2) this.getAccessToken();
     },
   },
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -72,7 +72,7 @@
 
       </svg>
       <Ranking />
-      <LoadingIcon :loading="loading" />
+      <!-- <LoadingIcon :loading="loading" /> -->
     </div>
   </div>
 </template>


### PR DESCRIPTION
# 変更
バリデーション機能を入れました。
- 4文字以上15文字以下
- 特殊記号とアルファベット大文字登録不可
- エラーメッセージの表示

# 注意点
現時点ではバリデーションを通った時点で、getAccessToken()を無条件に発火させています。サーバー側の準備が出来次第、userIdを取得するPOST通信にuserNameを付与して送ります。

また、ひらがなやカタカナ、漢字等は通るようにしています。(後に変更化)