### PR TITLE
ホイールでのズーム処理不具合修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -300,15 +300,21 @@ export default {
     },
     handleScroll(e) {
       e.preventDefault();
+      // カーソルの下にあるpieceの座標
       const targetPos = {
         x: Math.round((this.moveDist.x + e.pageX - this.$window.width / 2) / this.calcGridWidth()),
         y: Math.round((this.moveDist.y - e.pageY + this.$window.height / 2) / this.calcGridWidth()),
       };
+      // pieceの中心とカーソルの位置との差分
+      const adjustPos = {
+        x: e.pageX - this.calcObjPos(targetPos).x,
+        y: -(e.pageY - this.calcObjPos(targetPos).y),
+      };
       // ホイール移動量取得
       if (e.deltaY > 0) {
-        this.zoomout(targetPos);
+        this.zoomout({ targetPos, adjustPos });
       } else if (e.deltaY < 0) {
-        this.zoomin(targetPos);
+        this.zoomin({ targetPos, adjustPos });
       }
     },
     setCountTime() {

--- a/store/index.js
+++ b/store/index.js
@@ -52,17 +52,29 @@ export const mutations = {
     state.size = size;
     state.score = score;
   },
-  zoomout(state, targetPos) {
-    if (state.gridX + 1 > GRID_MIN && state.gridX + 1 < GRID_MAX) {
-      state.moveDist.x -= (window.innerWidth * targetPos.x) / (state.gridX * (state.gridX));
-      state.moveDist.y -= (window.innerWidth * targetPos.y) / (state.gridX * (state.gridX));
+  zoomout(state, { targetPos, adjustPos }) {
+    if (state.gridX + 1 >= GRID_MIN && state.gridX + 1 <= GRID_MAX) {
+      // gridX変更分位置調整
+      state.moveDist.x -= (window.innerWidth * targetPos.x) / (state.gridX * (state.gridX + 1))
+      // piece中心とカーソル位置との差分調整
+                          + adjustPos.x * (state.gridX / (state.gridX + 1));
+      // gridX変更分位置調整調整
+      state.moveDist.y -= (window.innerWidth * targetPos.y) / (state.gridX * (state.gridX + 1))
+      // piece中心とカーソル位置との差分調整
+                          + adjustPos.y * (state.gridX / (state.gridX + 1));
     }
     state.gridX = Math.max(GRID_MIN, Math.min(GRID_MAX, state.gridX + 1));
   },
-  zoomin(state, targetPos) {
-    if (state.gridX - 1 > GRID_MIN && state.gridX - 1 < GRID_MAX) {
-      state.moveDist.x += (window.innerWidth * targetPos.x) / (state.gridX * (state.gridX));
-      state.moveDist.y += (window.innerWidth * targetPos.y) / (state.gridX * (state.gridX));
+  zoomin(state, { targetPos, adjustPos }) {
+    if (state.gridX - 1 >= GRID_MIN && state.gridX - 1 <= GRID_MAX) {
+      // gridX変更分位置調整
+      state.moveDist.x += (window.innerWidth * targetPos.x) / (state.gridX * (state.gridX - 1))
+      // piece中心とカーソル位置との差分調整
+                          - adjustPos.x * (state.gridX / (state.gridX - 1));
+      // gridX変更分位置調整
+      state.moveDist.y += (window.innerWidth * targetPos.y) / (state.gridX * (state.gridX - 1))
+      // piece中心とカーソル位置との差分調整
+                          - adjustPos.y * (state.gridX / (state.gridX - 1));
     }
     state.gridX = Math.max(GRID_MIN, Math.min(GRID_MAX, state.gridX - 1));
   },


### PR DESCRIPTION
ホイールでのズーム処理について、以下の不具合を修正しました。

### 不具合内容
- ズーム時（特にズームイン）に座標がずれる

### 不具合原因
- コマの中心とカーソルの位置との座標のずれが積み重なることで計算に誤差が生じるため

### 修正内容
- コマの中心とカーソルの位置との差分を計算式に組み込んだ
